### PR TITLE
executor: generate snakemake reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,11 @@ jobs:
           sudo apt install libcurl4-openssl-dev libssl-dev
           sudo apt-get install libgnutls28-dev
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
+
       - name: Install Python dependencies
         run: |
           pip install --upgrade pip setuptools py
@@ -123,6 +128,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install python3-dev graphviz libgraphviz-dev pkg-config
 
       - name: Install Python dependencies
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@
 FROM python:3.8-slim
 # hadolint ignore=DL3008, DL3013, DL3015
 RUN apt-get update && \
-    apt-get install -y vim-tiny && \
+    apt-get install -y \
+    vim-tiny \
+    gcc \
+    graphviz \
+    graphviz-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     pip install --upgrade pip

--- a/reana_workflow_engine_snakemake/cli.py
+++ b/reana_workflow_engine_snakemake/cli.py
@@ -55,6 +55,7 @@ def run_snakemake_workflow_engine_adapter(
         workflow_workspace,
         workflow_file,
         workflow_parameters,
+        operational_options=operational_options,
     )
     if success:
         publisher.publish_workflow_status(workflow_uuid, finsihed_status)

--- a/reana_workflow_engine_snakemake/executor.py
+++ b/reana_workflow_engine_snakemake/executor.py
@@ -175,7 +175,12 @@ def submit_job(rjc_api_client, publisher, job_request_body):
 
 
 def run_jobs(
-    rjc_api_client, publisher, workflow_workspace, workflow_file, workflow_parameters
+    rjc_api_client,
+    publisher,
+    workflow_workspace,
+    workflow_file,
+    workflow_parameters,
+    operational_options={},
 ):
     """Run Snakemake jobs using custom REANA executor."""
     # Inject RJC API client and workflow status publisher in the REANA executor
@@ -196,5 +201,6 @@ def run_jobs(
         workdir=workflow_workspace,
         immediate_submit=True,
         notemp=True,
+        report=operational_options.get("report", "report.html"),
     )
     return success

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,32 +24,37 @@ gitdb==4.0.7              # via gitpython
 gitpython==3.1.18         # via snakemake
 idna==2.10                # via jsonschema, requests
 ipython-genutils==0.2.0   # via nbformat, traitlets
+jinja2==3.0.1             # via snakemake
 jsonpointer==2.1          # via jsonschema
 jsonref==0.2              # via bravado-core
 jsonschema[format]==3.2.0  # via bravado-core, nbformat, reana-commons, snakemake, swagger-spec-validator
 jupyter-core==4.7.1       # via nbformat
 kombu==4.6.11             # via reana-commons
+markupsafe==2.0.1         # via jinja2
 mock==3.0.5               # via reana-commons
 monotonic==1.6            # via bravado
 msgpack-python==0.5.6     # via bravado
 msgpack==1.0.2            # via bravado-core
 nbformat==5.1.3           # via snakemake
+networkx==2.6.2           # via snakemake
 psutil==5.8.0             # via snakemake
 pulp==2.4                 # via snakemake
+pygments==2.10.0          # via snakemake
+pygraphviz==1.7           # via snakemake
 pyparsing==2.4.7          # via amply
 pyrsistent==0.18.0        # via jsonschema
 python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2021.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons, snakemake, swagger-spec-validator
 ratelimiter==1.2.0.post0  # via snakemake
-reana-commons[snakemake]==0.8.0a21  # via reana-workflow-engine-snakemake (setup.py)
+reana-commons[snakemake]==0.8.0a23  # via reana-workflow-engine-snakemake (setup.py)
 requests==2.25.1          # via bravado, snakemake
 rfc3987==1.3.8            # via jsonschema
 simplejson==3.17.2        # via bravado, bravado-core
 six==1.16.0               # via bravado, bravado-core, fs, jsonschema, mock, python-dateutil, swagger-spec-validator
 smart-open==5.1.0         # via snakemake
 smmap==4.0.0              # via gitdb
-snakemake==6.5.3          # via reana-commons
+snakemake[reports]==6.5.3  # via reana-commons
 stopit==1.1.2             # via snakemake
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==2.7.3  # via bravado-core

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "reana-commons[snakemake]>=0.8.0a21,<0.9.0",
+    "reana-commons[snakemake]>=0.8.0a23,<0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Support `report` operational option to customize report filename

closes reanahub/reana-commons#284
closes reanahub/reana-commons#288

**TODO:**
- [x] Run `pip-compile --output-file=requirements.txt setup.py` once https://github.com/reanahub/reana-commons/pull/289 is merged.

**To test:**

1. Run any snakemake example
2. `reana-client ls` should show `report.html` in the workspace.
3. `reana-client download -w myworkflow report.html`
4. `open report.html`
5. Repeat the same steps modifying `reana-snakemake.yaml` to add `report` operational option to customise the report filename.
```diff
diff --git a/reana-snakemake.yaml b/reana-snakemake.yaml
index 49cb624..b359eca 100644
--- a/reana-snakemake.yaml
+++ b/reana-snakemake.yaml
@@ -7,6 +7,8 @@ inputs:
     - workflow/snakemake
   parameters:
     input: workflow/snakemake/inputs.yaml
+  options:
+    report: myreport.html
 workflow:
   type: snakemake
   file: workflow/snakemake/Snakefile
```