### PR TITLE
setup: switch to `snakemake_reports` extra

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2021.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons, snakemake, swagger-spec-validator
 ratelimiter==1.2.0.post0  # via snakemake
-reana-commons[snakemake]==0.8.0a23  # via reana-workflow-engine-snakemake (setup.py)
+reana-commons[snakemake_reports]==0.8.0a24	# via reana-workflow-engine-snakemake (setup.py)
 requests==2.25.1          # via bravado, snakemake
 rfc3987==1.3.8            # via jsonschema
 simplejson==3.17.2        # via bravado, bravado-core

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "reana-commons[snakemake]>=0.8.0a23,<0.9.0",
+    "reana-commons[snakemake_reports]>=0.8.0a24,<0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
To keep reports dependencies isolated and only installed in the workflow engine.

**TODO:**

- [ ] Run tests again when `reana-commons==0.8.0a24` is released.