### PR TITLE
executor: fix report generation

### DIFF
--- a/reana_workflow_engine_snakemake/config.py
+++ b/reana_workflow_engine_snakemake/config.py
@@ -14,3 +14,6 @@ MOUNT_CVMFS = os.getenv("REANA_MOUNT_CVMFS", "false")
 
 LOGGING_MODULE = "reana-workflow-engine-snakemake"
 """REANA Workflow Engine Snakemake logging module."""
+
+DEFAULT_SNAKEMAKE_REPORT_FILENAME = "report.html"
+"""Snakemake report default filename."""


### PR DESCRIPTION
closes #15

**To test:**

```console
$ reana-dev run-example -w snakemake
...
OK
$ reana-client download -w root6-roofit-snakemake-kubernetes 'report.html'
$ open report.html # opens browser with HTML report
```