### PR TITLE
executor: enable job paralellization via `nodes`

### DIFF
--- a/reana_workflow_engine_snakemake/cli.py
+++ b/reana_workflow_engine_snakemake/cli.py
@@ -46,7 +46,6 @@ def run_snakemake_workflow_engine_adapter(
     os.environ["workflow_workspace"] = workflow_workspace
     os.umask(REANA_WORKFLOW_UMASK)
 
-    log.info("Snakemake workflows are not yet supported. Skipping...")
     log.info(f"Workflow spec received: {workflow_file}")
     publisher.publish_workflow_status(workflow_uuid, running_status)
     success = run_jobs(

--- a/reana_workflow_engine_snakemake/executor.py
+++ b/reana_workflow_engine_snakemake/executor.py
@@ -219,8 +219,8 @@ def run_jobs(
         cluster="reana",
         config=workflow_parameters,
         workdir=workflow_workspace,
-        immediate_submit=True,
         notemp=True,
+        nodes=4,  # enables DAG parallelization
     )
     # Once the workflow is finished, generate the report,
     # taking into account the metadata generated.

--- a/reana_workflow_engine_snakemake/executor.py
+++ b/reana_workflow_engine_snakemake/executor.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 
 from reana_commons.utils import build_progress_message
 from snakemake import snakemake
-from snakemake.executors import GenericClusterExecutor
+from snakemake.executors import ClusterExecutor, GenericClusterExecutor
 from snakemake.logging import logger
 from snakemake import scheduler  # for monkeypatch
 
@@ -148,7 +148,10 @@ class REANAClusterExecutor(GenericClusterExecutor):
 
     def handle_job_success(self, job):
         """Override job success method to publish job status."""
-        super().handle_job_success(job)
+        # override handle_touch = True, to enable `touch()` in Snakefiles
+        super(ClusterExecutor, self).handle_job_success(
+            job, upload_remote=False, handle_log=False, handle_touch=True
+        )
 
         self._handle_job_status(job, "finished")
 


### PR DESCRIPTION
closes reanahub/reana#530

**To test:**
```zsh
$ cd ../reana-demo-cms-h4l
$ reana-client run -w cms-h4l-snake -f reana-snakemake.yaml

# Check that multiple jobs run at the same time
$ watch kubectl get pods
NAME                                                         READY   STATUS    RESTARTS   AGE
...
reana-run-batch-45d8a6e4-a28d-42fc-a35e-1348de2f070f-wk5wm   2/2     Running   0          40s
reana-run-job-6606716d-728f-4133-b2c6-722819fc5291-sh2ks     1/1     Running   0          9s
reana-run-job-7d2f71df-bfd0-4230-8dc7-f73bbb9f6b4f-qnlp5     1/1     Running   0          9s
...
```

