### PR TITLE
setup: upgrade `snakemake` version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,14 +47,14 @@ python-dateutil==2.8.1    # via bravado, bravado-core
 pytz==2021.1              # via bravado-core, fs
 pyyaml==5.4.1             # via bravado, bravado-core, reana-commons, snakemake, swagger-spec-validator
 ratelimiter==1.2.0.post0  # via snakemake
-reana-commons[snakemake_reports]==0.8.0a24	# via reana-workflow-engine-snakemake (setup.py)
+reana-commons[snakemake_reports]==0.8.0a26  # via reana-workflow-engine-snakemake (setup.py)
 requests==2.25.1          # via bravado, snakemake
 rfc3987==1.3.8            # via jsonschema
 simplejson==3.17.2        # via bravado, bravado-core
 six==1.16.0               # via bravado, bravado-core, fs, jsonschema, mock, python-dateutil, swagger-spec-validator
 smart-open==5.1.0         # via snakemake
 smmap==4.0.0              # via gitdb
-snakemake[reports]==6.5.3  # via reana-commons
+snakemake[reports]==6.8.0  # via reana-commons
 stopit==1.1.2             # via snakemake
 strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==2.7.3  # via bravado-core

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "reana-commons[snakemake_reports]>=0.8.0a24,<0.9.0",
+    "reana-commons[snakemake_reports]>=0.8.0a26,<0.9.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
closes reanahub/reana-commons#295

**To test:**
```console
$ reana-dev run-example -w snakemake
...
OK
$ cd ../reana-demo-cms-h4l
$ reana-client run -w h4l-snake -f reana-snakemake.yaml
...
$ reana-client download -w h4l-snake
==> SUCCESS: File results/mass4l_combine_userlvl3.pdf downloaded to ~/code/reanahub/reana-demo-cms-h4l.
$ open results/mass4l_combine_userlvl3.pdf