### PR TITLE
executor: increase number of `nodes`

### DIFF
--- a/reana_workflow_engine_snakemake/config.py
+++ b/reana_workflow_engine_snakemake/config.py
@@ -17,3 +17,6 @@ LOGGING_MODULE = "reana-workflow-engine-snakemake"
 
 DEFAULT_SNAKEMAKE_REPORT_FILENAME = "report.html"
 """Snakemake report default filename."""
+
+SNAKEMAKE_MAX_PARALLEL_JOBS = 100
+"""Snakemake maximum number of jobs that can run in parallel."""

--- a/reana_workflow_engine_snakemake/executor.py
+++ b/reana_workflow_engine_snakemake/executor.py
@@ -24,6 +24,7 @@ from reana_workflow_engine_snakemake.config import (
     DEFAULT_SNAKEMAKE_REPORT_FILENAME,
     LOGGING_MODULE,
     MOUNT_CVMFS,
+    SNAKEMAKE_MAX_PARALLEL_JOBS,
 )
 
 
@@ -230,7 +231,7 @@ def run_jobs(
         config=workflow_parameters,
         workdir=workflow_workspace,
         notemp=True,
-        nodes=4,  # enables DAG parallelization
+        nodes=SNAKEMAKE_MAX_PARALLEL_JOBS,  # enables DAG parallelization
         keep_logger=True,
     )
     # Once the workflow is finished, generate the report,


### PR DESCRIPTION
Set to 100, in order to allow high-parallelizable workflows jobs.

closes #19