### PR TITLE
executor: add kubernetes_job_timeout parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.8.1 (UNRELEASED)
 ---------------------------
 
+- Adds support for specifying ``kubernetes_job_timeout`` for Kubernetes compute backend jobs.
 - Adds polling job-controller to determine job statuses instead of checking files.
 
 Version 0.8.0 (2021-11-22)

--- a/reana_workflow_engine_snakemake/executor.py
+++ b/reana_workflow_engine_snakemake/executor.py
@@ -81,6 +81,9 @@ class REANAClusterExecutor(GenericClusterExecutor):
                     "kubernetes_memory_limit": job.resources.get(
                         "kubernetes_memory_limit"
                     ),
+                    "kubernetes_job_timeout": job.resources.get(
+                        "kubernetes_job_timeout"
+                    ),
                     "voms_proxy": job.resources.get("voms_proxy", False),
                     "htcondor_max_runtime": job.resources.get(
                         "htcondor_max_runtime", ""


### PR DESCRIPTION
closes reanahub/reana-job-controller#343

How to test:

This PR is part of a bigger group of PRs. Please refer to the addressed issue to see all of them.

1. Modify Snakemake helloworld example, with `kubernetes_job_timeout=20` (in seconds) and `sleeptime=1` (1 second so workflow will definitely run longer than 20 seconds):

`workflow/snakemake/inputs.yaml`
```yaml
sleeptime: 1  # <= here
helloworld: code/helloworld.py
inputfile: data/names.txt
```

`workflow/snakemake/Snakemake`
```yaml
...
rule helloworld:
   ...
    container:
        "docker://python:2.7-slim"
    resources:
        kubernetes_job_timeout=20  # <= here
    shell:
    ...
```

2. Start workflow `reana-client run -w snake-timeout -f reana-snakemake.yaml`

3. After 30 seconds, check using `reana-client list` if workflow failed.

4. Using `reana-client logs -w snakemake-timeout` check if the reason is `Job was killed due to timeout.` at the end.

5. Try to input string or object instead of integer for `kubernetes_job_timeout`, the workflow should fail and have logs indicating that. This will not work right now due to [this issue](https://github.com/reanahub/reana-workflow-controller/issues/426). It will be fixed after this PR.