### PR TITLE
executor, add job status polling

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ The list of contributors in alphabetical order:
 - `Marco Vidal <https://orcid.org/0000-0002-9363-4971>`_
 - `Sinclert Perez <https://www.linkedin.com/in/sinclert>`_
 - `Tibor Simko <https://orcid.org/0000-0001-7202-5803>`_
+- `Vladyslav Moisieienkov <https://orcid.org/0000-0001-9717-0775>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 0.8.1 (UNRELEASED)
+---------------------------
+
+- Adds polling job-controller to determine job statuses instead of checking files.
+
 Version 0.8.0 (2021-11-22)
 ---------------------------
 

--- a/reana_workflow_engine_snakemake/config.py
+++ b/reana_workflow_engine_snakemake/config.py
@@ -9,6 +9,7 @@
 """REANA Workflow Engine Snakemake configuration."""
 
 import os
+from enum import Enum
 
 MOUNT_CVMFS = os.getenv("REANA_MOUNT_CVMFS", "false")
 
@@ -20,3 +21,39 @@ DEFAULT_SNAKEMAKE_REPORT_FILENAME = "report.html"
 
 SNAKEMAKE_MAX_PARALLEL_JOBS = 100
 """Snakemake maximum number of jobs that can run in parallel."""
+
+POLL_JOBS_STATUS_SLEEP_IN_SECONDS = 10
+"""Time to sleep between polling for job status."""
+
+
+# defined in reana-db component, in reana_db/models.py file as JobStatus
+class JobStatus(Enum):
+    """Enumeration of job statuses.
+
+    Example:
+        JobStatus.started.name == "started"  # True
+    """
+
+    # FIXME: this state is not defined in reana-db but returned by r-job-controller
+    started = 6
+
+    created = 0
+    running = 1
+    finished = 2
+    failed = 3
+    stopped = 4
+    queued = 5
+
+
+# defined in reana-db component, in reana_db/models.py file as RunStatus
+class RunStatus(Enum):
+    """Enumeration of possible run statuses of a workflow."""
+
+    created = 0
+    running = 1
+    finished = 2
+    failed = 3
+    deleted = 4
+    stopped = 5
+    queued = 6
+    pending = 7


### PR DESCRIPTION
closes #33

Initial implementation of this PR relied on both file checking and polling in two separate threads. I don't think it was a good idea, so the final version completely relies on the polling job controller.

How to test:

1. Check out this branch and ensure that `snakemake-engine` Docker image is updated.

2. There are 3 main scenarios: 

- workflow `success`, 
- workflow `failed` due to an error inside workflow (e.g, incorrect command), 
- workflow `failed` because k8s or something else decided to stop it (e.g, due to timeout). 

You can easily test the first two scenarios. The third one requires more setup, check the review notes below for more details. The most important thing is to check that no bugs were introduced.

3. Check if the progress state is displayed correctly in `reana-client list --include-progress`

4. Check if engine and jobs logs are displayed

Review notes:

- I checked that the `kubernetes_job_timeout` parameter will work with this PR

- I tested it on `reana-demo-cms-h4l` and `reana-demo-root6` workflows