### PR TITLE
installation: fix Snakemake XRootD support

### DIFF
--- a/reana_workflow_engine_snakemake/version.py
+++ b/reana_workflow_engine_snakemake/version.py
@@ -14,4 +14,4 @@ by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.9.0a5"
+__version__ = "0.9.0a6"

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,4 @@
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-xrootd>=5.4.2,<6.0
+xrootd>=5.4.2,<5.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,7 +65,7 @@ vine==5.0.0               # via amqp, kombu
 webcolors==1.12           # via jsonschema
 werkzeug==2.2.2           # via reana-commons
 wrapt==1.14.1             # via snakemake
-xrootd==5.5.0             # via -r requirements.in
+xrootd==5.4.2             # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     ],
     "tests": tests_require,
     "xrootd": [
-        "xrootd>=5.4.2,<6.0",
+        "xrootd>=5.4.2,<5.4.3",
     ],
 }
 


### PR DESCRIPTION
Fixes Snakemake's XRootD remote storage input provider feature by pining XRootD to an older version.