### PR TITLE
executor: correctly report failed workflow

### DIFF
--- a/reana_workflow_engine_snakemake/executor.py
+++ b/reana_workflow_engine_snakemake/executor.py
@@ -129,11 +129,13 @@ class REANAClusterExecutor(GenericClusterExecutor):
         workflow_uuid = os.getenv("workflow_uuid", "default")
         job_id = job.reana_job_id
         log.info(f"{job.name} job is {job_status.name}. job_id: {job_id}")
-        message = {
-            "progress": build_progress_message(
-                **{job_status.name: {"total": 1, "job_ids": [job_id]}}
-            )
-        }
+        message = None
+        if job_id:
+            message = {
+                "progress": build_progress_message(
+                    **{job_status.name: {"total": 1, "job_ids": [job_id]}}
+                )
+            }
         self.publisher.publish_workflow_status(
             workflow_uuid, workflow_status.value, message=message
         )


### PR DESCRIPTION
When the submission of a job failed, a job with id `None` was incorrectly reported as failed.

Closes reanahub/reana-client#646

How to test:
1. Modify r-w-e-snakemake to simulate a failure during the submission of a job
    ```diff
    diff --git a/reana_workflow_engine_snakemake/executor.py b/reana_workflow_engine_snakemake/executor.py
    index d1607e4..9810704 100644
    --- a/reana_workflow_engine_snakemake/executor.py
    +++ b/reana_workflow_engine_snakemake/executor.py
    @@ -96,6 +96,7 @@ class REANAClusterExecutor(GenericClusterExecutor):
                         "slurm_partition": job.resources.get("slurm_partition"),
                         "slurm_time": job.resources.get("slurm_time"),
                     }
    +                raise Exception("Submission failed!")
                     job_id = submit_job(
                         self.rjc_api_client, self.publisher, job_request_body
                     )
    ```
2. Execute a workflow that uses snakemake
3. Run `reana-client status -w workflow`