### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -2,9 +2,15 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
-  range: "80...100"
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        base: auto
+        target: auto
+        threshold: 2%
 
 parsers:
   gcov:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Use Ubuntu LTS base image
-FROM ubuntu:20.04
+FROM docker.io/library/ubuntu:20.04
 
 # Use default answers in installation commands
 ENV DEBIAN_FRONTEND=noninteractive

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This file is part of REANA.
-# Copyright (C) 2021 CERN.
+# Copyright (C) 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -41,11 +41,11 @@ check_pytest () {
 }
 
 check_dockerfile () {
-    docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 }
 
 check_docker_build () {
-    docker build -t reanahub/reana-workflow-engine-snakemake .
+    docker build -t docker.io/reanahub/reana-workflow-engine-snakemake .
 }
 
 check_all () {


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.