### PR TITLE
utils: fix total job count to exclude restored jobs from workspace

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.1 (UNRELEASED)
 --------------------------
 
+- Fixes the total job count reported to workflow controller by excluding jobs restored from the workspace and not executed by Snakemake.
 - Fixes an issue where some workflows would be stuck waiting for already-finished jobs.
 
 Version 0.9.0 (2023-01-19)

--- a/reana_workflow_engine_snakemake/utils.py
+++ b/reana_workflow_engine_snakemake/utils.py
@@ -17,7 +17,9 @@ def publish_workflow_start(
     workflow_uuid: str, publisher: WorkflowStatusPublisher, job: Job
 ):
     """Publish to MQ the start of the workflow."""
-    job_count = len([rule for rule in job.dag.rules if not rule.norun])
+    job_count = len(
+        [j for j in (job.dag._needrun | job.dag._finished) if not j.rule.norun]
+    )
     total_jobs = {"total": job_count, "job_ids": []}
     status_running = 1
     publisher.publish_workflow_status(


### PR DESCRIPTION
Amend the total number of jobs in a workflow so that when Snakemake
detects that one or more jobs can be restored from the workspace (same
workflow caching) they are not considered in the total count, reflecting
Snakemake's local behaviour.

Closes #62.

### How to test
#### `roofit` example
1. Run the workflow normally with `reana-client run -w roofit-snakemake -f ./reana-snakemake.yaml`. The total number of jobs should be 2/2 (as usual)
2. Restart the workflow in the same workspace with `reana-client restart -w roofit-snakemake`. The total number of jobs should be 0/0, because the workflow is entirely restored from the workspace.
3. Change something in `code/fitdata.C` (such as a comment) and upload it to the workspace with `reana-client upload -w roofit-snakemake code/fitdata.C`
4. Restart the workflow in the same workspace with `reana-client restart -w roofit-snakemake`. The total number of jobs should be 1/1, because only the `fitdata` step is executed (`gendata` is restored from the "local cache").

#### `cms-h4l` example
1. Run the workflow normally with `reana-client run -w cms-h4l`. The total number of jobs should be 4/4 (as usual)
2. Restart the workflow in the same workspace with `reana-client restart -w cms-h4l`. The total number of jobs should be 0/0, because the workflow is entirely restored from the workspace.
3. Remove the `Higgs4L1file.root` (which is the input for the `make_plot` step, generated by `analyze_mc`) with `reana-client rm -w cms-h4l-snakemake.1.4 results/Higgs4L1file.root` and the final output plot: `reana-client rm -w cms-h4l-snakemake.1.4 results/mass4l_combine_userlvl3.pdf`
4. Restart the workflow in the same workspace with `reana-client restart -w cms-h4l`. The total number of jobs should be 2/2, because the `analyze_mc` step should regenerate the `Higgs4L1file.root` file and the `make_plot` step should create the final output plot.
