### PR TITLE
docker: integrate ImageMagick v6 with v7 wrapper for report thumbnails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Version 0.9.2 (UNRELEASED)
 --------------------------
 
+- Fixes creation of image thumbnails for output files in Snakemake HTML execution reports.
 - Fixes container image building on the arm64 architecture.
 
 Version 0.9.1 (2023-09-27)

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -y && \
         gnupg2 \
         graphviz \
         graphviz-dev \
+        imagemagick \
         krb5-config \
         krb5-user \
         libauthen-krb5-perl \
@@ -67,6 +68,12 @@ RUN apt-get update -y && \
 # Copy cluster component source code
 WORKDIR /code
 COPY . /code
+
+# Add magick wrapper command to simulate ImageMagick v7 that is necessary by Snakemake
+# to produce thumbnails in generated reports. The wrapper simply passes conversion
+# requests to ImageMagick v6 available on Ubuntu 20.04.
+COPY scripts/magick-wrapper.sh /usr/local/bin/magick
+RUN chmod +x /usr/local/bin/magick
 
 # Are we debugging?
 ARG DEBUG=0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,5 +19,6 @@ recursive-include docs *.py
 recursive-include docs *.png
 recursive-include docs *.rst
 recursive-include docs *.txt
-recursive-include tests *.py
 recursive-include reana_workflow_engine_snakemake *.json
+recursive-include scripts *.sh
+recursive-include tests *.py

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,6 +14,7 @@ set -o nounset
 
 check_script () {
     shellcheck run-tests.sh
+    shellcheck scripts/magick-wrapper.sh
 }
 
 check_pydocstyle () {

--- a/scripts/magick-wrapper.sh
+++ b/scripts/magick-wrapper.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Wrapper script to simulate ImageMagick v7 `magick convert` command required by Snakemake
+
+# If the first argument is 'convert', remove it
+if [ "$1" = "convert" ]; then
+   shift
+fi
+
+# Call the 'convert' command with the remaining arguments
+/usr/bin/convert "$@"


### PR DESCRIPTION
ImageMagick is needed by Snakemake to generate the thumbnails for the
files in the HTML reports. Snakemake uses ImageMagick v7 (called via
`magick convert`, but on Ubuntu 20.04 only ImageMagick v6 (called via
`convert`) is available, so this commit adds a script to mimic
ImageMagick v7 using the available version.

---

How to test:
Run a snakemake workflow in which the Snakefile contains report detail about the files produced by the workflow (details on how to do it on the [Snakemake documentation](https://snakemake.readthedocs.io/en/stable/snakefiles/reporting.html)) and check the difference in the engine logs and generated report with and without these changes to the image.

A Snakemake example that uses the roofit demo is available here: https://github.com/giuseppe-steduto/reana-demo-root6-roofit/tree/snakemake-improve-report
