### PR TITLE
build(docker): non-editable submodules in "latest" mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,14 @@ ARG DEBUG=0
 RUN if [ "${DEBUG}" -gt 0 ]; then pip install --no-cache-dir -e ".[debug,xrootd]"; else pip install --no-cache-dir ".[xrootd]"; fi;
 
 # Are we building with locally-checked-out shared modules?
-# hadolint ignore=SC2102
-RUN if test -e modules/reana-commons; then pip install --no-cache-dir -e modules/reana-commons[kubernetes] --upgrade; fi
+# hadolint ignore=DL3013
+RUN if test -e modules/reana-commons; then \
+      if [ "${DEBUG}" -gt 0 ]; then \
+        pip install --no-cache-dir -e "modules/reana-commons[kubernetes]" --upgrade; \
+      else \
+        pip install --no-cache-dir "modules/reana-commons[kubernetes]" --upgrade; \
+      fi \
+    fi
 
 # Check for any broken Python dependencies
 RUN pip check


### PR DESCRIPTION
When running development cluster in "latest" mode, install shared modules in non-editable mode. The editable mode should be reserved only for development clusters in "debug" mode with the live code reload.