### PR TITLE
feat(executor): upgrade to Snakemake v7.32.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2023 CERN.
+# Copyright (C) 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -101,6 +101,10 @@ RUN pip check
 # Set useful environment variables
 ENV TERM=xterm \
     PYTHONPATH=/workdir
+
+# Create and set cache directory to be used by Snakemake
+RUN mkdir -p /.cache/snakemake && chmod ug+rwx /.cache/snakemake
+ENV XDG_CACHE_HOME=/.cache
 
 # Set image labels
 LABEL org.opencontainers.image.authors="team@reanahub.io"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2023 CERN.
+# Copyright (C) 2021, 2022, 2023, 2024 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -51,7 +51,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    "reana-commons[snakemake_reports]>=0.9.4,<0.10.0",
+    "reana-commons[snakemake_reports]>=0.9.6,<0.10.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Amend the overridden executor to reflect the changes in the new version
of Snakemake, in particular with regard to the change of the
`_wait_for_jobs` method into a coroutine.

Closes #31
Closes reanahub/reana-client#655
