### PR TITLE
build(docker): pin setuptools 70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip 'setuptools<65.6' py wheel
+          pip install --upgrade pip 'setuptools<71' py wheel
           pip install -e .[all]
 
       - name: Run Sphinx documentation with doctests
@@ -162,7 +162,7 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install --upgrade pip 'setuptools<65.6' py
+          pip install --upgrade pip 'setuptools<71' py
           pip install twine wheel
           pip install -e .[all]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update -y && \
           libxrootd-client-dev \
           xrootd-client) \
     fi && \
-    pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir --upgrade pip 'setuptools<71' && \
     pip install --no-cache-dir -r /code/requirements.txt && \
     apt-get remove -y \
         cmake \


### PR DESCRIPTION
Pin `setuptools` to the maximum version of 70 to allow working on Ubuntu 20.04 LTS based environments. (New versions of `setuptools` are not compatible.)

Note that this fix is necessary only for the `maint-0.9` branches and the REANA 0.9 release series. In `master` we have switched to Ubuntu 24.04 LTS based environments and Python 3.12 and no pinning is necessary there.