### PR TITLE
ci(linting): add remaining linting and formatting checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,20 @@ jobs:
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --check-jsonlint
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,20 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code fomatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --check-prettier
+
   lint-yamllint:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,20 @@ jobs:
           npm install jsonlint --global
           ./run-tests.sh --check-jsonlint
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --check-markdownlint
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,18 @@ jobs:
           pip install check-manifest
           ./run-tests.sh --check-manifest
 
+  format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --check-shfmt
+
+
   docs-sphinx:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,23 @@ jobs:
           sudo apt-get install shfmt
           ./run-tests.sh --check-shfmt
 
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --check-yamllint
 
   docs-sphinx:
     runs-on: ubuntu-24.04
@@ -222,8 +239,7 @@ jobs:
   release-docker:
     runs-on: ubuntu-24.04
     if: >
-      vars.RELEASE_DOCKER == 'true' &&
-      github.event_name == 'push' &&
+      vars.RELEASE_DOCKER == 'true' && github.event_name == 'push' &&
       startsWith(github.ref, 'refs/tags/')
     needs:
       - docs-sphinx

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+
+# Allow multiple headings with same content (for different releases)
+MD024: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.pytest_cache
+CHANGELOG.md
+docs/openapi.json

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,9 +5,13 @@
     ".": {
       "changelog-sections": [
         { "type": "build", "section": "Build", "hidden": false },
-        { "type": "feat", "section": "Features", "hidden": false  },
+        { "type": "feat", "section": "Features", "hidden": false },
         { "type": "fix", "section": "Bug fixes", "hidden": false },
-        { "type": "perf", "section": "Performance improvements", "hidden": false },
+        {
+          "type": "perf",
+          "section": "Performance improvements",
+          "hidden": false
+        },
         { "type": "refactor", "section": "Code refactoring", "hidden": false },
         { "type": "style", "section": "Code style", "hidden": false },
         { "type": "test", "section": "Test suite", "hidden": false },

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,6 +5,7 @@ The list of contributors in alphabetical order:
 - [Agisilaos Kounelis](https://orcid.org/0000-0001-9312-3189)
 - [Alp Tuna](https://orcid.org/0009-0001-1915-3993)
 - [Audrius Mecionis](https://orcid.org/0000-0002-3759-1663)
+- [Cameron McClymont](https://orcid.org/0009-0002-0176-5251)
 - [Camila Diaz](https://orcid.org/0000-0001-5543-797X)
 - [Giuseppe Steduto](https://orcid.org/0009-0002-1258-8553)
 - [Manuel Giffels](https://orcid.org/0000-0003-0193-3032)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
+<!-- markdownlint-disable MD013 -->
+
 # Changelog
 
 ## [0.9.4](https://github.com/reanahub/reana-workflow-engine-snakemake/compare/0.9.3...0.9.4) (2024-11-29)
-
 
 ### Build
 
@@ -9,18 +10,15 @@
 * **docker:** pin setuptools 70 ([#102](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/102)) ([b27c9cf](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/b27c9cfa21603ecc1554931f23c945d3f9e256d6))
 * **python:** bump shared REANA packages as of 2024-11-28 ([#104](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/104)) ([fb9efc8](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/fb9efc8267c24ce65e8d188a5171d8abd5531cd7))
 
-
 ### Features
 
 * **executor:** allow Compute4PUNCH backend options ([#97](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/97)) ([4b00c52](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/4b00c523eb8750f49262471a43c9deefad1021d3))
-
 
 ### Bug fixes
 
 * **executor:** override default resources to remove mem/disk ([#91](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/91)) ([572a83f](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/572a83f5190c7cae95a4607b792f4b6e0c39262c)), closes [#90](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/90)
 
 ## [0.9.3](https://github.com/reanahub/reana-workflow-engine-snakemake/compare/0.9.2...0.9.3) (2024-03-04)
-
 
 ### Build
 
@@ -29,22 +27,18 @@
 * **python:** bump all required packages as of 2024-03-04 ([#85](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/85)) ([66e81e2](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/66e81e2148ad4ba72099a90dbb556454df3cfc99))
 * **python:** bump shared REANA packages as of 2024-03-04 ([#85](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/85)) ([d07f91f](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/d07f91f6f725050c681c66ec920727f26db3fdbf))
 
-
 ### Features
 
 * **config:** get max number of parallel jobs from env vars ([#84](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/84)) ([69cfad4](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/69cfad460b240e5dbafea42137d891d6fea607a5))
 * **executor:** upgrade to Snakemake v7.32.4 ([#81](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/81)) ([4a3f359](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/4a3f3592c8dd3f323e81850f5bdfae45ea893825))
 
-
 ### Bug fixes
 
 * **progress:** handle stopped jobs ([#78](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/78)) ([4829d80](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/4829d80a5e03ab5788fb6646bd792a7345abe14a))
 
-
 ### Code refactoring
 
 * **docs:** move from reST to Markdown ([#82](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/82)) ([31de94f](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/31de94f79b1955328961d506ce9d8d4efbe7227f))
-
 
 ### Continuous integration
 
@@ -55,43 +49,42 @@
 * **release-please:** update version in Dockerfile ([#77](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/77)) ([3c35a67](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/3c35a67db7c181e23f28fda6152f40c8251f9b74))
 * **shellcheck:** fix exit code propagation ([#80](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/80)) ([ad15c0d](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/ad15c0d0e2020fd874a9eed5c4b36e320129b9eb))
 
-
 ### Documentation
 
 * **authors:** complete list of contributors ([#83](https://github.com/reanahub/reana-workflow-engine-snakemake/issues/83)) ([4782678](https://github.com/reanahub/reana-workflow-engine-snakemake/commit/478267864a20da6ab4d7f99be5592fcf19a20ca1))
 
 ## 0.9.2 (2023-12-12)
 
-- Adds automated container image building for amd64 architecture.
-- Adds metadata labels to Dockerfile.
-- Fixes creation of image thumbnails for output files in Snakemake HTML execution reports.
-- Fixes container image building on the arm64 architecture.
+* Adds automated container image building for amd64 architecture.
+* Adds metadata labels to Dockerfile.
+* Fixes creation of image thumbnails for output files in Snakemake HTML execution reports.
+* Fixes container image building on the arm64 architecture.
 
 ## 0.9.1 (2023-09-27)
 
-- Changes remote storage file support to use XRootD 5.6.0.
-- Fixes the reported total number of jobs for restarted workflows by excluding cached jobs that were simply reused from previous runs in the workspace and not really executed by Snakemake.
-- Fixes an issue where workflows could get stuck waiting for already-finished jobs.
-- Fixes container image names to be Podman-compatible.
+* Changes remote storage file support to use XRootD 5.6.0.
+* Fixes the reported total number of jobs for restarted workflows by excluding cached jobs that were simply reused from previous runs in the workspace and not really executed by Snakemake.
+* Fixes an issue where workflows could get stuck waiting for already-finished jobs.
+* Fixes container image names to be Podman-compatible.
 
 ## 0.9.0 (2023-01-19)
 
-- Adds support for specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
-- Adds support for XRootD remote file locations in workflow specification definitions.
-- Adds support for Kerberos authentication for workflow orchestration.
-- Adds support for Rucio authentication for workflow jobs.
-- Changes global setting of maximum number of parallel jobs to 300.
-- Changes the base image of the component to Ubuntu 20.04 LTS and reduces final Docker image size by removing build-time dependencies.
-- Fixes progress reporting for failed workflow jobs.
+* Adds support for specifying `slurm_partition` and `slurm_time` for Slurm compute backend jobs.
+* Adds support for XRootD remote file locations in workflow specification definitions.
+* Adds support for Kerberos authentication for workflow orchestration.
+* Adds support for Rucio authentication for workflow jobs.
+* Changes global setting of maximum number of parallel jobs to 300.
+* Changes the base image of the component to Ubuntu 20.04 LTS and reduces final Docker image size by removing build-time dependencies.
+* Fixes progress reporting for failed workflow jobs.
 
 ## 0.8.1 (2022-02-07)
 
-- Adds support for specifying `kubernetes_job_timeout` for Kubernetes compute backend jobs.
-- Adds polling job-controller to determine job statuses instead of checking files.
+* Adds support for specifying `kubernetes_job_timeout` for Kubernetes compute backend jobs.
+* Adds polling job-controller to determine job statuses instead of checking files.
 
 ## 0.8.0 (2021-11-22)
 
-- Adds initial REANA Snakemake executor implementation.
-- Adds support for snakemake reports generation.
-- Adds support for REANA custom resources.
-- Adds support for parallel job execution.
+* Adds initial REANA Snakemake executor implementation.
+* Adds support for snakemake reports generation.
+* Adds support for REANA custom resources.
+* Adds support for parallel job execution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Bug reports, issues, feature requests, and other contributions are welcome. If you find
-a demonstrable problem that is caused by the REANA code, please:
+Bug reports, issues, feature requests, and other contributions are welcome. If
+you find a demonstrable problem that is caused by the REANA code, please:
 
-1. Search for [already reported problems](https://github.com/reanahub/reana-workflow-engine-snakemake/issues).
-2. Check if the issue has been fixed or is still reproducible on the
-   latest `master` branch.
+1. Search for
+   [already reported problems](https://github.com/reanahub/reana-workflow-engine-snakemake/issues).
+2. Check if the issue has been fixed or is still reproducible on the latest
+   `master` branch.
 3. Create an issue, ideally with **a test case**.
 
 If you create a pull request fixing a bug or implementing a feature, you can run

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,7 @@ include Dockerfile
 include LICENSE
 include pytest.ini
 exclude .readthedocs.yaml
+exclude .editorconfig
 prune docs/_build
 recursive-include docs *.py
 recursive-include docs *.png

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,8 @@ include LICENSE
 include pytest.ini
 exclude .readthedocs.yaml
 exclude .editorconfig
+exclude .prettierrc.yaml
+exclude .prettierignore
 prune docs/_build
 recursive-include docs *.py
 recursive-include docs *.png

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 
 ## About
 
-REANA-Workflow-Engine-Snakemake is a component of the [REANA](http://www.reana.io/)
-reusable and reproducible research data analysis platform. It takes care of
-instantiating, executing and managing [Snakemake](https://snakemake.github.io/) based
-computational workflows.
+REANA-Workflow-Engine-Snakemake is a component of the
+[REANA](http://www.reana.io/) reusable and reproducible research data analysis
+platform. It takes care of instantiating, executing and managing
+[Snakemake](https://snakemake.github.io/) based computational workflows.
 
 ## Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD041 -->
+<!-- markdownlint-disable MD033 -->
+
 ```{include} ../README.md
 :end-before: "## About"
 ```

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -91,6 +91,10 @@ check_shfmt() {
     shfmt -d .
 }
 
+check_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 check_all() {
     check_commitlint
     check_shellcheck
@@ -105,6 +109,7 @@ check_all() {
     check_jsonlint
     check_yamllint
     check_shfmt
+    check_markdownlint
 }
 
 if [ $# -eq 0 ]; then
@@ -127,6 +132,7 @@ case $arg in
 --check-jsonlint) check_jsonlint ;;
 --check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
+--check-markdownlint) check_markdownlint ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -83,6 +83,10 @@ check_jsonlint() {
     find . -name "*.json" -exec jsonlint -q {} \+
 }
 
+check_yamllint() {
+    yamllint .
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -99,6 +103,7 @@ check_all() {
     check_dockerfile
     check_docker_build
     check_jsonlint
+    check_yamllint
     check_shfmt
 }
 
@@ -120,6 +125,7 @@ case $arg in
 --check-dockerfile) check_dockerfile ;;
 --check-docker-build) check_docker_build ;;
 --check-jsonlint) check_jsonlint ;;
+--check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -95,6 +95,10 @@ check_markdownlint() {
     markdownlint-cli2 "**/*.md"
 }
 
+check_prettier() {
+    prettier -c .
+}
+
 check_all() {
     check_commitlint
     check_shellcheck
@@ -110,6 +114,7 @@ check_all() {
     check_yamllint
     check_shfmt
     check_markdownlint
+    check_prettier
 }
 
 if [ $# -eq 0 ]; then
@@ -133,6 +138,7 @@ case $arg in
 --check-yamllint) check_yamllint ;;
 --check-shfmt) check_shfmt ;;
 --check-markdownlint) check_markdownlint ;;
+--check-prettier) check_prettier ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -79,6 +79,10 @@ check_docker_build() {
     docker build -t docker.io/reanahub/reana-workflow-engine-snakemake .
 }
 
+check_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 check_shfmt() {
     shfmt -d .
 }
@@ -94,6 +98,7 @@ check_all() {
     check_pytest
     check_dockerfile
     check_docker_build
+    check_jsonlint
     check_shfmt
 }
 
@@ -114,6 +119,7 @@ case $arg in
 --check-pytest) check_pytest ;;
 --check-dockerfile) check_dockerfile ;;
 --check-docker-build) check_docker_build ;;
+--check-jsonlint) check_jsonlint ;;
 --check-shfmt) check_shfmt ;;
 --check-all) check_all ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+check_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
@@ -31,7 +31,7 @@ check_commitlint () {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -43,43 +43,47 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+check_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_pydocstyle () {
+check_pydocstyle() {
     pydocstyle reana_workflow_engine_snakemake
 }
 
-check_black () {
+check_black() {
     black --check .
 }
 
-check_flake8 () {
+check_flake8() {
     flake8 .
 }
 
-check_manifest () {
+check_manifest() {
     check-manifest
 }
 
-check_sphinx () {
+check_sphinx() {
     sphinx-build -qnNW docs docs/_build/html
 }
 
-check_pytest () {
+check_pytest() {
     pytest
 }
 
-check_dockerfile () {
-    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 < Dockerfile
+check_dockerfile() {
+    docker run -i --rm docker.io/hadolint/hadolint:v2.12.0 <Dockerfile
 }
 
-check_docker_build () {
+check_docker_build() {
     docker build -t docker.io/reanahub/reana-workflow-engine-snakemake .
 }
 
-check_all () {
+check_shfmt() {
+    shfmt -d .
+}
+
+check_all() {
     check_commitlint
     check_shellcheck
     check_pydocstyle
@@ -90,6 +94,7 @@ check_all () {
     check_pytest
     check_dockerfile
     check_docker_build
+    check_shfmt
 }
 
 if [ $# -eq 0 ]; then
@@ -99,15 +104,17 @@ fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    --check-pydocstyle) check_pydocstyle;;
-    --check-black) check_black;;
-    --check-flake8) check_flake8;;
-    --check-manifest) check_manifest;;
-    --check-sphinx) check_sphinx;;
-    --check-pytest) check_pytest;;
-    --check-dockerfile) check_dockerfile;;
-    --check-docker-build) check_docker_build;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--check-commitlint) check_commitlint "$@" ;;
+--check-shellcheck) check_shellcheck ;;
+--check-pydocstyle) check_pydocstyle ;;
+--check-black) check_black ;;
+--check-flake8) check_flake8 ;;
+--check-manifest) check_manifest ;;
+--check-sphinx) check_sphinx ;;
+--check-pytest) check_pytest ;;
+--check-dockerfile) check_dockerfile ;;
+--check-docker-build) check_docker_build ;;
+--check-shfmt) check_shfmt ;;
+--check-all) check_all ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1 ;;
 esac

--- a/scripts/magick-wrapper.sh
+++ b/scripts/magick-wrapper.sh
@@ -3,7 +3,7 @@
 
 # If the first argument is 'convert', remove it
 if [ "$1" = "convert" ]; then
-   shift
+    shift
 fi
 
 # Call the 'convert' command with the remaining arguments


### PR DESCRIPTION
Introduce remaining file formatting checks to `run-tests.sh` and to the GitHub CI:
- [x] `.editorconfig` for consistent character formatting across the repo
- [x] `yamllint` for YAML linting
- [x] `jsonlint` for JSON linting
- [x] `shfmt` for shell script formatting
- [x] `markdownlint` for markdown linting
- [x] `prettier` for various other formatting such as `.js` files

Closes #112