### PR TITLE
feat(runner): upgrade to Snakemake v9

### DIFF
--- a/reana_workflow_engine_snakemake/runner.py
+++ b/reana_workflow_engine_snakemake/runner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2023, 2024 CERN.
+# Copyright (C) 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,9 +10,15 @@
 
 import os
 import logging
+import re
 from pathlib import Path
 
 from snakemake.api import SnakemakeApi
+from snakemake.logging import (
+    DefaultFilter,
+    DefaultFormatter,
+    logger as snakemake_logger,
+)
 from snakemake.settings.types import (
     ConfigSettings,
     DAGSettings,
@@ -30,6 +36,8 @@ from snakemake_interface_report_plugins.settings import (
 )
 from snakemake_interface_common.exceptions import WorkflowError
 
+from reana_commons.config import REANA_LOG_FORMAT
+
 from reana_workflow_engine_snakemake.config import (
     LOGGING_MODULE,
     SNAKEMAKE_MAX_PARALLEL_JOBS,
@@ -39,6 +47,68 @@ from reana_workflow_engine_snakemake.config import (
 from reana_workflow_engine_snakemake import executor as reana_executor
 
 log = logging.getLogger(LOGGING_MODULE)
+
+
+class SnakemakeLoggingFormatter(logging.Formatter):
+    """Format Snakemake log records for REANA output.
+
+    Delegates to Snakemake's ``DefaultFormatter`` to produce human-readable
+    message bodies (e.g. PROGRESS → "2 of 5 steps (40%) done"), then wraps
+    the result in ``REANA_LOG_FORMAT``.  Records whose formatted body is
+    empty or ``"None"`` are suppressed.
+    """
+
+    _SNAKEMAKE_TIMESTAMP_RE = re.compile(r"^\[.*?\]\n")
+
+    def __init__(self):
+        """Initialise Snakemake formatter with REANA log format."""
+        super().__init__(fmt=REANA_LOG_FORMAT)
+        self._snakemake_formatter = DefaultFormatter(quiet=set())
+
+    def format(self, record):
+        """Format a log record."""
+        body = self._snakemake_formatter.format(record)
+        if not body or body == "None":
+            return ""
+        # Strip Snakemake's own timestamp (e.g. "[Mon Mar  2 11:19:30 2026]\n")
+        # since REANA_LOG_FORMAT already provides one.
+        body = self._SNAKEMAKE_TIMESTAMP_RE.sub("", body)
+        record.msg = body
+        record.args = None
+        return super().format(record)
+
+
+def _setup_snakemake_logging(printshellcmds=True):
+    """Replace Snakemake's default logging handlers with a REANA-friendly one.
+
+    This must be called **after** ``SnakemakeApi(...)`` has been created,
+    because the ``SnakemakeApi`` constructor triggers ``LoggerManager`` setup
+    which installs Snakemake's default ``ColorizingTextHandler``.
+
+    The function:
+    * sets ``propagate = False`` on the ``snakemake.logging`` logger so that
+      messages no longer bubble up to the root logger (eliminates duplicate
+      and broken ``"None"`` lines);
+    * removes all existing handlers;
+    * adds a single ``StreamHandler`` with ``SnakemakeLoggingFormatter`` and
+      Snakemake's ``DefaultFilter``.
+    """
+    snakemake_logger.propagate = False
+
+    for handler in snakemake_logger.handlers[:]:
+        snakemake_logger.removeHandler(handler)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(SnakemakeLoggingFormatter())
+    handler.addFilter(
+        DefaultFilter(
+            quiet=set(),
+            debug_dag=False,
+            dryrun=False,
+            printshellcmds=printshellcmds,
+        )
+    )
+    snakemake_logger.addHandler(handler)
 
 
 my_registry = ExecutorPluginRegistry()
@@ -69,11 +139,13 @@ def run_jobs(
 ):
     """Run Snakemake jobs using custom REANA executor."""
     workflow_file_path = os.path.join(workflow_workspace, workflow_file)
+    printshellcmds = True
     with SnakemakeApi(
         OutputSettings(
-            printshellcmds=True,
+            printshellcmds=printshellcmds,
         )
     ) as snakemake_api:
+        _setup_snakemake_logging(printshellcmds=printshellcmds)
         try:
             workflow_api = snakemake_api.workflow(
                 resource_settings=ResourceSettings(nodes=SNAKEMAKE_MAX_PARALLEL_JOBS),

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of REANA.
-# Copyright (C) 2021, 2022, 2023, 2024, 2025 CERN.
+# Copyright (C) 2021, 2022, 2023, 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -30,7 +30,7 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a2,<0.96.0",
+        "pytest-reana>=0.95.0a7,<0.96.0",
     ],
 }
 
@@ -41,7 +41,7 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "reana-commons[snakemake,snakemake-xrootd]>=0.95.0a12,<0.96.0",
+    "reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]>=0.95.0a13,<0.96.0",
     "pygments>=2.18.0",  # necessary for Snakemake reports
 ]
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of REANA.
+# Copyright (C) 2026 CERN.
+#
+# REANA is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""REANA-Workflow-Engine-Snakemake runner tests."""
+
+import logging
+from unittest.mock import patch
+
+from reana_workflow_engine_snakemake.runner import (
+    SnakemakeLoggingFormatter,
+    _setup_snakemake_logging,
+)
+
+
+class TestSnakemakeLoggingFormatter:
+    """Tests for SnakemakeLoggingFormatter."""
+
+    def _make_record(self, msg="hello"):
+        """Create a minimal log record."""
+        return logging.LogRecord(
+            name="snakemake",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg=msg,
+            args=None,
+            exc_info=None,
+        )
+
+    def test_empty_body_returns_empty_string(self):
+        """Test that empty formatted body is suppressed."""
+        formatter = SnakemakeLoggingFormatter()
+        record = self._make_record("")
+        assert record.msg == ""
+        with patch.object(formatter, "_snakemake_formatter") as mock_fmt:
+            mock_fmt.format.return_value = ""
+            assert formatter.format(record) == ""
+
+    def test_none_body_returns_empty_string(self):
+        """Test that 'None' formatted body is suppressed."""
+        formatter = SnakemakeLoggingFormatter()
+        record = self._make_record("None")
+        assert record.msg == "None"
+        with patch.object(formatter, "_snakemake_formatter") as mock_fmt:
+            mock_fmt.format.return_value = "None"
+            assert formatter.format(record) == ""
+
+    def test_timestamp_is_stripped(self):
+        """Test that Snakemake timestamp prefix is removed."""
+        formatter = SnakemakeLoggingFormatter()
+        record = self._make_record()
+        with patch.object(formatter, "_snakemake_formatter") as mock_fmt:
+            mock_fmt.format.return_value = "[Mon Mar  2 11:19:30 2026]\nDone."
+            assert "[Mon Mar" in mock_fmt.format.return_value
+            result = formatter.format(record)
+            assert "[Mon Mar" not in result
+            assert "Done." in result
+
+
+class TestSetupSnakemakeLogging:
+    """Tests for _setup_snakemake_logging."""
+
+    def test_replaces_handlers(self):
+        """Test that existing handlers are replaced with a single REANA one."""
+        from snakemake.logging import logger as snakemake_logger
+
+        old_handlers = snakemake_logger.handlers[:]
+        old_propagate = snakemake_logger.propagate
+        try:
+            # Ensure multiple handlers exist; the logger may start empty
+            snakemake_logger.addHandler(logging.StreamHandler())
+            snakemake_logger.addHandler(logging.StreamHandler())
+            assert len(snakemake_logger.handlers) >= 2
+            assert not isinstance(
+                snakemake_logger.handlers[0].formatter, SnakemakeLoggingFormatter
+            )
+            _setup_snakemake_logging()
+            assert snakemake_logger.propagate is False
+            assert len(snakemake_logger.handlers) == 1
+            assert isinstance(
+                snakemake_logger.handlers[0].formatter, SnakemakeLoggingFormatter
+            )
+        finally:
+            snakemake_logger.handlers = old_handlers
+            snakemake_logger.propagate = old_propagate


### PR DESCRIPTION
Upgrade from Snakemake 8.27.1 to 9.16.3. Add the new `snakemake-kubernetes` extra from `reana-commons`, which provides the `snakemake-executor-plugin-kubernetes` package required by Snakemake v9.

Fix duplicate output and "None" log messages caused by Snakemake v9's new pluggable logging system by replacing the default log handler with a custom one that delegates to DefaultFormatter and wraps output in REANA_LOG_FORMAT, stripping redundant timestamps.