### PR TITLE
refactor(pytest): drop pytest-reana and use pytest directly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 [pytest]
-addopts = --ignore=docs --cov=reana_workflow_engine_snakemake --cov-report=term-missing --cov-report=xml
+addopts = --ignore=docs --ignore=modules --cov=reana_workflow_engine_snakemake --cov-report=term-missing --cov-report=xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ pygments==2.19.2          # via reana-workflow-engine-snakemake (setup.py)
 python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes
 pytz==2026.1.post1        # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes, reana-commons, snakemake, swagger-spec-validator, yte
-reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]==0.95.0a14  # via reana-workflow-engine-snakemake (setup.py)
+reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]==0.95.0a16	# via reana-workflow-engine-snakemake (setup.py)
 referencing==0.37.0       # via jsonschema, jsonschema-specifications, snakemake
 requests==2.33.0          # via bravado, bravado-core, kubernetes, requests-oauthlib, snakemake
 requests-oauthlib==2.0.0  # via kubernetes

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,40 +7,36 @@
 amqp==5.3.1               # via kombu
 appdirs==1.4.4            # via fs, snakemake
 argparse-dataclass==2.0.0  # via snakemake-interface-common, snakemake-interface-executor-plugins, yte
-arrow==1.4.0              # via isoduration
 attrs==26.1.0             # via jsonschema, referencing
 bracex==2.6               # via wcmatch
 bravado==10.3.2           # via reana-commons
 bravado-core==6.1.0       # via bravado, reana-commons
-certifi==2026.2.25        # via kubernetes, requests
+certifi==2026.4.22        # via kubernetes, requests
 cffi==2.0.0               # via cryptography
-charset-normalizer==3.4.6  # via requests
+charset-normalizer==3.4.7  # via requests
 checksumdir==1.1.9        # via reana-commons
-click==8.3.1              # via reana-commons
+click==8.3.3              # via reana-commons
 conda-inject==1.3.2       # via snakemake
 configargparse==1.7.5     # via snakemake, snakemake-interface-common
 connection-pool==0.0.3    # via snakemake
-cryptography==46.0.6      # via google-auth
+cryptography==48.0.0      # via google-auth
 docutils==0.22.4          # via snakemake
 dpath==2.2.0              # via snakemake, yte
 durationpy==0.10          # via kubernetes
 fastjsonschema==2.21.2    # via nbformat
-fqdn==1.5.1               # via jsonschema
 fs==2.4.16                # via reana-commons
-gherkin-official==39.0.0  # via reana-commons
+gherkin-official==39.1.0  # via reana-commons
 gitdb==4.0.12             # via gitpython
-gitpython==3.1.46         # via snakemake
-google-auth==2.49.1       # via kubernetes
+gitpython==3.1.50         # via snakemake
+google-auth==2.52.0       # via kubernetes
 humanfriendly==10.0       # via snakemake, snakemake-interface-storage-plugins
-idna==3.11                # via jsonschema, requests
+idna==3.14                # via jsonschema, requests
 immutables==0.21          # via snakemake
-importlib-resources==6.5.2  # via swagger-spec-validator
-isoduration==20.11.0      # via jsonschema
+importlib-resources==7.1.0  # via swagger-spec-validator
 jinja2==3.1.6             # via snakemake
 jsonpointer==3.1.1        # via jsonschema
 jsonref==1.1.0            # via bravado-core
-jsonschema[format]==4.26.0  # via bravado-core, nbformat, reana-commons, snakemake, swagger-spec-validator
-jsonschema-specifications==2025.9.1  # via jsonschema
+jsonschema[format]==3.2.0  # via bravado-core, nbformat, reana-commons, snakemake, swagger-spec-validator
 jupyter-core==5.9.1       # via nbformat
 kombu==5.6.2              # via reana-commons
 kubernetes==32.0.1        # via snakemake-executor-plugin-kubernetes
@@ -52,28 +48,28 @@ msgpack-python==0.5.6     # via bravado
 nbformat==5.10.4          # via snakemake
 oauthlib==3.3.1           # via kubernetes, requests-oauthlib
 packaging==25.0           # via kombu, snakemake, snakemake-interface-common
-parse==1.21.1             # via reana-commons
-platformdirs==4.9.4       # via jupyter-core
+parse==1.22.0             # via reana-commons
+platformdirs==4.9.6       # via jupyter-core
 psutil==7.2.2             # via snakemake
-pulp==3.3.0               # via snakemake
+pulp==3.3.1               # via snakemake
 pyasn1==0.6.3             # via pyasn1-modules
 pyasn1-modules==0.4.2     # via google-auth
 pycparser==3.0            # via cffi
-pygments==2.19.2          # via reana-workflow-engine-snakemake (setup.py)
-python-dateutil==2.9.0.post0  # via arrow, bravado, bravado-core, kubernetes
-pytz==2026.1.post1        # via bravado-core
+pygments==2.20.0          # via reana-workflow-engine-snakemake (setup.py)
+pyrsistent==0.20.0        # via jsonschema
+python-dateutil==2.9.0.post0  # via bravado, bravado-core, kubernetes
+pytz==2026.2              # via bravado-core
 pyyaml==6.0.3             # via bravado, bravado-core, conda-inject, kubernetes, reana-commons, snakemake, swagger-spec-validator, yte
-reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]==0.95.0a16	# via reana-workflow-engine-snakemake (setup.py)
-referencing==0.37.0       # via jsonschema, jsonschema-specifications, snakemake
-requests==2.33.0          # via bravado, bravado-core, kubernetes, requests-oauthlib, snakemake
+reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]==0.95.0a16  # via reana-workflow-engine-snakemake (setup.py)
+referencing==0.37.0       # via snakemake
+requests==2.34.0          # via bravado, bravado-core, kubernetes, requests-oauthlib, snakemake
 requests-oauthlib==2.0.0  # via kubernetes
 reretry==0.11.8           # via snakemake
-rfc3339-validator==0.1.4  # via jsonschema
 rfc3987==1.3.8            # via jsonschema
-rpds-py==0.30.0           # via jsonschema, referencing
-simplejson==3.20.2        # via bravado, bravado-core
-six==1.17.0               # via bravado, bravado-core, fs, kubernetes, mock, python-dateutil, rfc3339-validator
-smart-open==7.5.1         # via snakemake
+rpds-py==0.30.0           # via referencing
+simplejson==4.1.1         # via bravado, bravado-core
+six==1.17.0               # via bravado, bravado-core, fs, jsonschema, kubernetes, mock, python-dateutil
+smart-open==7.6.1         # via snakemake
 smmap==5.0.3              # via gitdb
 snakemake==9.16.3         # via reana-commons
 snakemake-executor-plugin-kubernetes==0.5.1  # via reana-commons
@@ -84,22 +80,22 @@ snakemake-interface-report-plugins==1.3.0  # via snakemake
 snakemake-interface-scheduler-plugins==2.0.2  # via snakemake
 snakemake-interface-storage-plugins==4.4.1  # via snakemake, snakemake-storage-plugin-xrootd
 snakemake-storage-plugin-xrootd==1.0.0  # via reana-commons
+strict-rfc3339==0.7       # via jsonschema
 swagger-spec-validator==3.0.4  # via bravado-core
 tabulate==0.10.0          # via snakemake
 tenacity==9.1.4           # via snakemake-interface-storage-plugins
 throttler==1.2.3          # via snakemake, snakemake-interface-executor-plugins, snakemake-interface-storage-plugins
-traitlets==5.14.3         # via jupyter-core, nbformat
+traitlets==5.15.0         # via jupyter-core, nbformat
 typing-extensions==4.15.0  # via bravado, gherkin-official, referencing, swagger-spec-validator
-tzdata==2025.3            # via arrow, kombu
-uri-template==1.3.0       # via jsonschema
-urllib3==2.6.3            # via kubernetes, requests
+tzdata==2026.2            # via kombu
+urllib3==2.7.0            # via kubernetes, requests
 vine==5.1.0               # via amqp, kombu
 wcmatch==8.4.1            # via reana-commons
 webcolors==25.10.0        # via jsonschema
 websocket-client==1.9.0   # via kubernetes
-werkzeug==3.1.7           # via reana-commons
+werkzeug==3.1.8           # via reana-commons
 wrapt==2.1.2              # via smart-open, snakemake, snakemake-interface-storage-plugins
-xrootd==5.9.1             # via snakemake-storage-plugin-xrootd
+xrootd==5.9.3             # via snakemake-storage-plugin-xrootd
 yte==1.9.4                # via snakemake
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ extras_require = {
         "sphinx-rtd-theme>=0.1.9",
     ],
     "tests": [
-        "pytest-reana>=0.95.0a7,<0.96.0",
+        "pytest>=7.0.0,<9.0.0",
+        "pytest-cov>=3.0.0,<4.0",
     ],
 }
 
@@ -41,7 +42,7 @@ for key, reqs in extras_require.items():
     extras_require["all"].extend(reqs)
 
 install_requires = [
-    "reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]>=0.95.0a14,<0.96.0",
+    "reana-commons[snakemake,snakemake-kubernetes,snakemake-xrootd]>=0.95.0a16,<0.96.0",
     "pygments>=2.18.0",  # necessary for Snakemake reports
 ]
 


### PR DESCRIPTION
This engine never used any fixture from pytest-reana; the dependency
only pulled pytest and friends transitively. Replace it with direct
pytest usage.

Closes https://github.com/reanahub/pytest-reana/issues/156