### PR TITLE
fix(config): use glob for egg-info in flake8 exclude

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
     dist
     docs
     coverage.xml
-    reana_workflow_engine_snakemake.egg-info
+    *.egg-info
     .*/
     env/
     .git


### PR DESCRIPTION
Replace the package-specific `reana_workflow_engine_snakemake.egg-info` entry with the `*.egg-info` glob for consistency with other REANA repos and to keep the entry correct regardless of the package name.

Closes reanahub/reana#882